### PR TITLE
Fix test_320_push and add methods for working with tags

### DIFF
--- a/gitapi/gitapi.py
+++ b/gitapi/gitapi.py
@@ -116,8 +116,8 @@ class Repo(object):
             args.extend([key, kwargs[key]])
         if points_at:
             args.extend(['--points-at', points_at])
-        if template:
-            args.append(template)
+        if pattern:
+            args.append(pattern)
         res = self.git_command("tag", "-l", *args)
         return [tag for tag in res.split("\n") if tag]
 

--- a/gitapi/gitapi.py
+++ b/gitapi/gitapi.py
@@ -20,6 +20,7 @@ class GitException(Exception):
         super(GitException, self).__init__(msg)
         self.exit_code = exit_code
         
+
 class Revision(object):
     """A representation of a revision.
     Available fields are::
@@ -43,6 +44,7 @@ class Revision(object):
     def __eq__(self, other):
         """Returns true if self.node == other.node"""
         return self.node == other.node
+
 
 class Repo(object):
     """A representation of a Mercurial repository"""
@@ -70,6 +72,7 @@ class Repo(object):
             raise GitException("Error running %s:\n\tErr: %s\n\tOut: %s\n\tExit: %s" 
                             % (cmd,err,out,proc.returncode), exit_code=proc.returncode)
         return out
+
     def git_command(self, *args):
         """Run a git command on this repo and return the result.
         Throws on error."""    
@@ -106,7 +109,14 @@ class Repo(object):
         """Create the branch named 'name'"""
         return self.git_command("branch", name, start)
 
+    def git_tags(self):
+        """Gets a list with the names of all tags"""
+        res = self.git_command("tag")
+        return [tag for tag in res.split("\n") if tag]
 
+    def git_tag(self, name):
+        """Create the tag named 'name'"""
+        return self.git_command("tag", name)
 
     def git_merge(self, reference):
         """Merge reference to current"""
@@ -219,7 +229,6 @@ class Repo(object):
             sect_cfg[sub] = value.strip()
         self.cfg = cfg
         return cfg
-
 
     def config(self, section, key):
         """Return the value of a configuration variable"""

--- a/gitapi/gitapi.py
+++ b/gitapi/gitapi.py
@@ -109,9 +109,12 @@ class Repo(object):
         """Create the branch named 'name'"""
         return self.git_command("branch", name, start)
 
-    def git_tags(self):
+    def git_tags(self, points_at=None):
         """Gets a list with the names of all tags"""
-        res = self.git_command("tag")
+        args = []
+        if points_at:
+            args.extend(['--points-at', points_at])
+        res = self.git_command("tag", *args)
         return [tag for tag in res.split("\n") if tag]
 
     def git_tag(self, name):

--- a/gitapi/gitapi.py
+++ b/gitapi/gitapi.py
@@ -109,12 +109,16 @@ class Repo(object):
         """Create the branch named 'name'"""
         return self.git_command("branch", name, start)
 
-    def git_tags(self, points_at=None):
-        """Gets a list with the names of all tags"""
+    def git_tags(self, pattern=None, points_at=None, **kwargs):
+        """Get repository tags"""
         args = []
+        for key in kwargs:
+            args.extend([key, kwargs[key]])
         if points_at:
             args.extend(['--points-at', points_at])
-        res = self.git_command("tag", *args)
+        if template:
+            args.append(template)
+        res = self.git_command("tag", "-l", *args)
         return [tag for tag in res.split("\n") if tag]
 
     def git_tag(self, name):

--- a/gitapi/testgitapi.py
+++ b/gitapi/testgitapi.py
@@ -212,7 +212,7 @@ class TestGitAPI(unittest.TestCase):
         self.clone.git_add('cities')
         message = "[CLONE] Added one file."
         self.clone.git_commit(message)
-        self.clone.git_push("../test-clone-bare")
+        self.clone.git_push("../test-clone-bare", branch="master")
 
         self.assertEquals(self.clone.git_id(), self.bareclone.git_id())
         # check summary of pushed tip


### PR DESCRIPTION
On Windows Server 2008 R2, git version 1.8.3.msysgit.0
`test_320_push` all the time falls with folowing exception:

```
gitapi.GitException: Error running git push ../test-clone-bare:
Err: fatal: You are pushing to remote '../test-clone-bare', which is not the upstream of your current branch 'master', without telling me what to push to update which remote branch.
```

I fixed this and also added two methods for working with tags.
